### PR TITLE
Improve handling of empty or whitespace-only lines

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,7 @@
 		"semi": "off",
 		"indent": ["error", "tab"]
 	},
+	"ignorePatterns": ["**/fixtures/**"],
 	"overrides": [
 		{
 			"files": ["**/*.ts"],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [Unreleased]
+
+### Fixes
+
+- Ignore empty or whitespace-only lines when calculating minimum indentation of the snippet (#17)
+
 ## [0.2.0]
 
 ### Features

--- a/src/lib/documentHelpers.ts
+++ b/src/lib/documentHelpers.ts
@@ -7,9 +7,18 @@ export function linesForIndexes(document: TextDocument, lineIndexes: number[]): 
 }
 
 export function minimumIndentationForLineIndexes(document: TextDocument, lineIndexes: number[]): number {
-	const indentationLevels = lineIndexes.map((lineIndex) => {
-		return document.lineAt(lineIndex).firstNonWhitespaceCharacterIndex;
-	});
+	const indentationLevels = lineIndexes.reduce<number[]>((indentationLevels, lineIndex) => {
+		const line = document.lineAt(lineIndex);
+
+		// Skip empty lines so they don't skew the calculation results
+		if (line.isEmptyOrWhitespace) {
+			return indentationLevels;
+		}
+
+		indentationLevels.push(line.firstNonWhitespaceCharacterIndex);
+
+		return indentationLevels;
+	}, []);
 
 	const minimumIndentationLevelInSelection = Math.min(...indentationLevels);
 	return minimumIndentationLevelInSelection;

--- a/src/test/fixtures/.editorconfig
+++ b/src/test/fixtures/.editorconfig
@@ -1,0 +1,1 @@
+root = true

--- a/src/test/fixtures/javascript-example.js
+++ b/src/test/fixtures/javascript-example.js
@@ -8,4 +8,9 @@ class MyThing {
   doSomethingElse() {
     throw new Error('Nope!');
   }
+
+    emptyFunction() {
+
+  
+    }
 }

--- a/src/test/suite/lib/documentHelpers.test.ts
+++ b/src/test/suite/lib/documentHelpers.test.ts
@@ -36,6 +36,10 @@ describe('Document Helpers', function () {
 		it('calculates the correct minimum indentation level for multiple lines', () => {
 			assert.equal(minimumIndentationForLineIndexes(document, [1, 2, 3]), 2);
 		});
+
+		it('calculates the correct minimum indentation level when lines contain an empty line', () => {
+			assert.equal(minimumIndentationForLineIndexes(document, [11, 12, 13, 14]), 4);
+		});
 	});
 
 	context('contentOfLinesWithAdjustedIndentation', async () => {

--- a/src/test/suite/lib/textHelpers.test.ts
+++ b/src/test/suite/lib/textHelpers.test.ts
@@ -23,6 +23,10 @@ describe('Text Helpers', () => {
 		content: 'doSomethingElse() {\n  throw new Error(\'Nope!\');\n}',
 		selection: new Selection(7, 2, 9, 3)
 	};
+	const testSelection3: TestSelection = {
+		content: '}\n\ndoSomethingElse() {',
+		selection: new Selection(5, 0, 7, 21)
+	};
 	let document: TextDocument;
 
 	before(async () => {
@@ -58,6 +62,12 @@ describe('Text Helpers', () => {
 		it('generates the correct text when the cursor is on a newline', () => {
 			assert.deepEqual(testSelection1.content,
 				generateCopyableText(document, new Selection(testSelection1.selection.start, new Position(5, 0)))
+			);
+		});
+
+		it('generates the correct text when selection contains empty line', () => {
+			assert.deepEqual(testSelection3.content,
+				generateCopyableText(document, testSelection3.selection)
 			);
 		});
 


### PR DESCRIPTION
Fixes #17 

The extension now ignores lines that are entirely empty or contain only whitespace when it's calculating the indentation level up unto which to adjust the selected snippet.